### PR TITLE
Fix: Add note for Linux users to install python3-tk if app fails to run

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,11 @@ Run the main script to launch the GUI:
 python src/main.py
 ```
 
-Make sure you have Python 3 installed.
+If the app fails to run, the reason can be related to the Operating System. I tried this on Windows first, and it's working perfectly. But in Linux I have to install this
+
+```bash
+sudo apt install python3-tk
+```
 
 ## Flow-Chart
 


### PR DESCRIPTION
While testing the app across different operating systems, I found that it runs perfectly on Windows. However, on Linux, the app may fail to run due to a missing dependency: `python3-tk`.

To resolve this, Linux users should install the required package using the following command:

```bash
sudo apt install python3-tk
```

This note has been added to improve cross-platform compatibility and help users troubleshoot OS-specific issues more easily.